### PR TITLE
Torna o atributo de imagem opcional ao atualizar projeto

### DIFF
--- a/backend/src/controllers/project.controller.ts
+++ b/backend/src/controllers/project.controller.ts
@@ -69,16 +69,17 @@ class ProjectController {
       !updatedProject.title ||
       !updatedProject.description ||
       !updatedProject.tags ||
-      !updatedProject.link ||
-      !req.file
+      !updatedProject.link
     ) {
       return res
         .status(422)
         .json({ message: "Solicitação inválida. Verifique os parâmetros enviados." });
     }
 
-    const downloadURL = await uploadFile(req.file!);
-    updatedProject.imgUrl = downloadURL;
+    if (req.file) {
+      const downloadURL = await uploadFile(req.file);
+      updatedProject.imgUrl = downloadURL;
+    }
 
     const updated = await ProjectService.updateProject(projectId, updatedProject);
 


### PR DESCRIPTION
**Descrição**: Faz com que não seja mais necessário enviar o atributo de imagem do projeto, ao atualizar um. Foi feita uma leve alteração no controller de Project.

**Revisor do PR:** @Eriberto-lab 
**Fechamento da issue 80:** closes #80 