### PR TITLE
Adiciona rota simples só para pingar a API.

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -13,8 +13,14 @@ const app = express();
 app.use(cors()); // Use o middleware cors
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+
 app.listen(3000, () => console.log(`Express rodando na porta ${process.env.PORT}`));
+app.get("/ping", (_req, res) => {
+  res.status(200).json({ message: "A API está online" });
+});
+
 app.use(multerMiddleware);
+
 app.use(loginRouter);
 app.use(userRouter);
 app.use(projectRouter);


### PR DESCRIPTION
**Descrição**: Adiciona rota simples de ping na API. O endpoint é `GET /ping`. O retorno é simplesmente uma mensagem informando que a API está rodando.

**Revisor do PR**: @pedroaugusto04 
**Fechamento da issue 113**: closes #113 